### PR TITLE
Use fork for macos multiprocessing context

### DIFF
--- a/asari/utils.py
+++ b/asari/utils.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 import os
 import time
 import hashlib
+from sys import platform
 import zipfile
 from io import BytesIO
 from importlib import resources as pkg_resources
@@ -53,7 +54,8 @@ def bulk_process(command, arguments, jobs_per_worker=False):
     Not considering distributed computing (e.g. dask) because it's easier to parallelize projects than computing. 
     '''
     n_workers = jobs_per_worker if (jobs_per_worker and jobs_per_worker != 'auto') else mp.cpu_count()
-    with mp.Pool(n_workers) as client:
+    ctx = mp.get_context('fork') if platform != 'win32' else mp.get_context()
+    with ctx.Pool(n_workers) as client:
         return client.starmap(command, [(arg,) for arg in arguments])
     
     


### PR DESCRIPTION
Dear Dr. Li,

When running asari in an intel mac through a conda-installed version of python3.11 I encountered a runtime error that stems from the multiprocessing module. The module is trying to spawn a new process instead of forking (changed for macos after python 3.8 - requires if __main__ guard). Switching the context fixes the problem - should be safe enough.

The error:
```
1/multiprocessing/spawn.py", line 140, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.
        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:
            if __name__ == '__main__':
                freeze_support()
                ...
        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
```

Sincerely,
Marios